### PR TITLE
Update the URL to the tinymce .js file

### DIFF
--- a/src/element_tinymce.erl
+++ b/src/element_tinymce.erl
@@ -27,7 +27,7 @@ render_element(Rec = #tinymce{text=Text, class=Class}) ->
 
 wire_init(ID, #tinymce{plugins=Plugins, toolbar1=TB1, toolbar2=TB2, toolbar3=TB3, menubar=Menubar, options=Options}) ->
     Json = build_json_options(ID, Plugins, TB1, TB2, TB3, Menubar, Options),
-    Url = <<"//tinymce.cachefly.net/4.0/tinymce.min.js">>,
+    Url = <<"//cdn.tinymce.com/4/tinymce.min.js">>,
     Init =
         <<"Nitrogen.$dependency_register_function('~s', function() {
             tinymce.init(~s);


### PR DESCRIPTION
Tinymce has changed the URL.  The new URL seem to remain unchanged when new versions in 4.x are released.
